### PR TITLE
feat: introduce additional CKEditor theming

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,7 +21,7 @@ function isSvgRule(rule) {
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-a11y'],
   webpackFinal: config => {
     config.module.rules.forEach(rule => {
       if (isCssRule(rule)) {

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@zendeskgarden/stylelint-config"
+  "extends": "@zendeskgarden/stylelint-config",
+  "rules": {
+    "selector-max-specificity": null
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@ckeditor/ckeditor5-react": "3.0.0",
     "@ckeditor/ckeditor5-theme-lark": "24.0.0",
     "@ckeditor/ckeditor5-widget": "24.0.0",
+    "@storybook/addon-a11y": "6.1.15",
     "@storybook/addon-actions": "6.1.10",
     "@storybook/addon-essentials": "6.1.10",
     "@storybook/addon-links": "6.1.10",

--- a/src/stories/GardenEditor.stories.js
+++ b/src/stories/GardenEditor.stories.js
@@ -16,7 +16,7 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
-import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
+import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
@@ -31,8 +31,8 @@ import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import { add } from '@ckeditor/ckeditor5-utils/src/translation-service';
 import { getEnvKeystrokeText } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
-// import GardenEditor from '../gardeneditor';
 import './theme/styles.css';
+import { CodeBlockUI } from './plugins/CodeBlockUI';
 import { INITIAL_DATA } from './initialData';
 
 const EDITOR_LOCAL_STORAGE_KEY = 'ckeditor5-demo-1';
@@ -84,7 +84,8 @@ export const Default = () => {
           List,
           BlockQuote,
           Heading,
-          CodeBlock,
+          CodeBlockEditing,
+          CodeBlockUI,
           Widget
         ],
         toolbar: [
@@ -92,6 +93,7 @@ export const Default = () => {
           'bold',
           'italic',
           'underline',
+          'code',
           '|',
           'bulletedList',
           'numberedList',
@@ -99,7 +101,6 @@ export const Default = () => {
           'indent',
           '|',
           'blockquote',
-          'code',
           'codeBlock',
           'link',
           'horizontalLine'

--- a/src/stories/plugins/CodeBlockUI.js
+++ b/src/stories/plugins/CodeBlockUI.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import codeBlockIcon from '@zendeskgarden/svg-icons/src/16/terminal-window-stroke.svg';
+import { getNormalizedAndLocalizedLanguageDefinitions } from '@ckeditor/ckeditor5-code-block/src/utils';
+
+export class CodeBlockUI extends Plugin {
+  init() {
+    const editor = this.editor;
+    const t = editor.t;
+    const componentFactory = editor.ui.componentFactory;
+    const normalizedLanguageDefs = getNormalizedAndLocalizedLanguageDefinitions(editor);
+    const defaultLanguageDefinition = normalizedLanguageDefs[0];
+
+    componentFactory.add('codeBlock', locale => {
+      const command = editor.commands.get('codeBlock');
+
+      const buttonView = new ButtonView(locale);
+
+      buttonView.set({
+        label: t('Insert code block'),
+        tooltip: true,
+        keystroke: 'CTRL+SHIFT+6',
+        icon: codeBlockIcon,
+        isToggleable: true
+      });
+
+      buttonView.bind('isEnabled').to(command);
+
+      buttonView.on('execute', () => {
+        editor.execute('codeBlock', {
+          language: defaultLanguageDefinition.language
+        });
+
+        editor.editing.view.focus();
+      });
+
+      return buttonView;
+    });
+  }
+}

--- a/src/stories/theme/_button.css
+++ b/src/stories/theme/_button.css
@@ -1,24 +1,35 @@
-.ck {
-  &.ck-button {
-    &:focus {
-      /* stylelint-disable-next-line color-function-notation */
-      box-shadow: rgba(31, 115, 183, .35) 0 0 0 3px; /* BLUE-600 */
-    }
+.ck.ck-button {
+  &:focus {
+    /* stylelint-disable-next-line color-function-notation */
+    box-shadow: rgba(31, 115, 183, .35) 0 0 0 3px; /* BLUE-600 */
+  }
 
-    &:focus, &:active {
-      border-color: transparent;
-    }
+  &:focus,
+  &:active {
+    border-color: transparent;
+  }
 
-    &:not(.ck-disabled) {
-      cursor: pointer;
-    }
+  &:not(.ck-disabled) {
+    cursor: pointer;
+  }
 
-    &:not(.ck-disabled):hover .ck-button__icon {
+  & .ck-button__icon {
+    color: #68737d; /* GREY-600 */
+  }
+
+  &:hover:not(.ck-disabled,.ck-on) {
+    & .ck-button__icon {
       color: #49545c; /* GREY-700 */
     }
+  }
 
-    &.ck-disabled:active {
-      box-shadow: none;
+  &.ck-on {
+    & .ck-button__icon {
+      color: #2f3941; /* GREY-800 */
     }
+  }
+
+  &.ck-disabled:active {
+    box-shadow: none;
   }
 }

--- a/src/stories/theme/_button.css
+++ b/src/stories/theme/_button.css
@@ -1,8 +1,24 @@
-/* stylelint-disable-next-line selector-max-specificity */
-.ck.ck-button:not(.ck-disabled):hover .ck-button__icon {
-  color: #49545c; /* GREY-700 */
-}
+.ck {
+  &.ck-button {
+    &:focus {
+      /* stylelint-disable-next-line color-function-notation */
+      box-shadow: rgba(31, 115, 183, .35) 0 0 0 3px; /* BLUE-600 */
+    }
 
-.ck.ck-button:not(.ck-disabled) {
-  cursor: pointer;
+    &:focus, &:active {
+      border-color: transparent;
+    }
+
+    &:not(.ck-disabled) {
+      cursor: pointer;
+    }
+
+    &:not(.ck-disabled):hover .ck-button__icon {
+      color: #49545c; /* GREY-700 */
+    }
+
+    &.ck-disabled:active {
+      box-shadow: none;
+    }
+  }
 }

--- a/src/stories/theme/_code-block.css
+++ b/src/stories/theme/_code-block.css
@@ -1,15 +1,15 @@
-.ck-content {
-  & pre {
-    margin: 0;
-    border-radius: var(--ck-border-radius-small);
-    background-color: #f8f9f9; /* GREY-100 */
-    padding: var(--ck-spacing-large);
-    overflow: auto;
-    white-space: pre;
-    color: var(--ck-color-base-text);
+.ck-content pre {
+  margin: 0;
+  margin-top: var(--ck-spacing-large);
+  margin-bottom: var(--ck-spacing-large);
+  border-radius: var(--ck-border-radius-small);
+  background-color: #f8f9f9; /* GREY-100 */
+  padding: var(--ck-spacing-large);
+  overflow: auto;
+  white-space: pre;
+  color: var(--ck-color-base-text);
 
-    & code {
-      background-color: inherit;
-    }
+  & code {
+    background-color: inherit;
   }
 }

--- a/src/stories/theme/_code-block.css
+++ b/src/stories/theme/_code-block.css
@@ -1,0 +1,15 @@
+.ck-content {
+  & pre {
+    margin: 0;
+    border-radius: var(--ck-border-radius-small);
+    background-color: #f8f9f9; /* GREY-100 */
+    padding: var(--ck-spacing-large);
+    overflow: auto;
+    white-space: pre;
+    color: var(--ck-color-base-text);
+
+    & code {
+      background-color: inherit;
+    }
+  }
+}

--- a/src/stories/theme/_dropdown.css
+++ b/src/stories/theme/_dropdown.css
@@ -9,3 +9,11 @@
     }
   }
 }
+
+.ck[dir='rtl'].ck-dropdown .ck-dropdown__button {
+  &.ck-on {
+    & .ck-dropdown__arrow {
+      transform: rotate(-180deg);
+    }
+  }
+}

--- a/src/stories/theme/_dropdown.css
+++ b/src/stories/theme/_dropdown.css
@@ -1,0 +1,11 @@
+.ck.ck-dropdown .ck-dropdown__button {
+  & .ck-dropdown__arrow {
+    transition: transform .25s ease-in-out 0s, color .25s ease-in-out 0s;
+  }
+
+  &.ck-on {
+    & .ck-dropdown__arrow {
+      transform: rotate(180deg);
+    }
+  }
+}

--- a/src/stories/theme/_dropdown.css
+++ b/src/stories/theme/_dropdown.css
@@ -32,6 +32,28 @@
     animation: .2s cubic-bezier(.15, .85, .35, 1.2);
     border-radius: var(--ck-border-radius) !important;
 
+    &:not(.ck-dropdown__panel-visible) {
+      display: inline-block;
+      transition: opacity .2s ease-in-out, .2s visibility 0s linear;
+      visibility: hidden;
+      opacity: 0;
+    }
+
+    &.ck-dropdown__panel-visible {
+      visibility: visible;
+      opacity: 1;
+
+      &.ck-dropdown__panel_ne,
+      &.ck-dropdown__panel_nw {
+        animation-name: zd-menu--top-open;
+      }
+
+      &.ck-dropdown__panel_se,
+      &.ck-dropdown__panel_sw {
+        animation-name: zd-menu--bottom-open;
+      }
+    }
+
     & > :first-child {
       margin-top: var(--ck-spacing-standard);
     }
@@ -43,14 +65,12 @@
     &.ck-dropdown__panel_ne,
     &.ck-dropdown__panel_nw {
       bottom: calc(100% + 4px);
-      animation-name: zd-menu--top-open;
     }
 
     &.ck-dropdown__panel_se,
     &.ck-dropdown__panel_sw {
       top: calc(100% + 4px);
       bottom: auto;
-      animation-name: zd-menu--bottom-open;
     }
 
     & .ck-list .ck-list__item .ck-button {

--- a/src/stories/theme/_dropdown.css
+++ b/src/stories/theme/_dropdown.css
@@ -1,19 +1,74 @@
-.ck.ck-dropdown .ck-dropdown__button {
-  & .ck-dropdown__arrow {
-    transition: transform .25s ease-in-out 0s, color .25s ease-in-out 0s;
+/* stylelint-disable declaration-no-important,
+  max-nesting-depth, selector-max-compound-selectors */
+
+@keyframes zd-menu--top-open {
+  0% {
+    transform: translateY(var(--ck-spacing-extra-large));
+  }
+}
+
+@keyframes zd-menu--bottom-open {
+  0% {
+    transform: translateY(calc(var(--ck-spacing-extra-large) * -1));
+  }
+}
+
+.ck.ck-dropdown {
+  & .ck-button.ck-dropdown__button {
+    & .ck-dropdown__arrow {
+      transition: transform .25s ease-in-out 0s, color .25s ease-in-out 0s;
+    }
+
+    &.ck-on {
+      border-radius: var(--ck-border-radius);
+
+      & .ck-dropdown__arrow {
+        transform: rotate(180deg);
+      }
+    }
   }
 
-  &.ck-on {
-    & .ck-dropdown__arrow {
-      transform: rotate(180deg);
+  & .ck-dropdown__panel {
+    animation: .2s cubic-bezier(.15, .85, .35, 1.2);
+    border-radius: var(--ck-border-radius) !important;
+
+    & > :first-child {
+      margin-top: var(--ck-spacing-standard);
+    }
+
+    & > :last-child {
+      margin-bottom: var(--ck-spacing-standard);
+    }
+
+    &.ck-dropdown__panel_ne,
+    &.ck-dropdown__panel_nw {
+      bottom: calc(100% + 4px);
+      animation-name: zd-menu--top-open;
+    }
+
+    &.ck-dropdown__panel_se,
+    &.ck-dropdown__panel_sw {
+      top: calc(100% + 4px);
+      bottom: auto;
+      animation-name: zd-menu--bottom-open;
+    }
+
+    & .ck-list .ck-list__item .ck-button {
+      border-radius: 0 !important;
     }
   }
 }
 
-.ck[dir='rtl'].ck-dropdown .ck-dropdown__button {
-  &.ck-on {
+.ck[dir='rtl'].ck-dropdown {
+  & .ck-button.ck-dropdown__button {
     & .ck-dropdown__arrow {
-      transform: rotate(-180deg);
+      transition: transform .25s ease-in-out 0s, color .25s ease-in-out 0s;
+    }
+
+    &.ck-on {
+      & .ck-dropdown__arrow {
+        transform: rotate(-180deg);
+      }
     }
   }
 }

--- a/src/stories/theme/_editor.css
+++ b/src/stories/theme/_editor.css
@@ -1,8 +1,8 @@
-.ck.ck-editor__editable_inline {
+.ck.ck-editor__editable {
   padding: 0 var(--ck-spacing-large);
-}
 
-/* Hide widget mobile type-around feature */
-.ck.ck-editor__editable .ck-widget .ck-widget__type-around__button {
-  display: none;
+  /* Hide widget mobile type-around feature */
+  & .ck-widget .ck-widget__type-around__button {
+    display: none;
+  }
 }

--- a/src/stories/theme/_editor.css
+++ b/src/stories/theme/_editor.css
@@ -3,7 +3,6 @@
 }
 
 /* Hide widget mobile type-around feature */
-/* stylelint-disable-next-line selector-max-specificity */
 .ck.ck-editor__editable .ck-widget .ck-widget__type-around__button {
   display: none;
 }

--- a/src/stories/theme/_horizontal-line.css
+++ b/src/stories/theme/_horizontal-line.css
@@ -1,5 +1,22 @@
+/* stylelint-disable selector-max-compound-selectors,
+   selector-combinator-space-before, indentation,
+   declaration-no-important */
+
 .ck-content hr {
-  margin: var(--ck-spacing-extra-large) 0;
+  margin: var(--ck-spacing-standard) 0;
   background-color: #d8dcde; /* GREY-300 */
   height: 1px;
+}
+
+.ck .ck-widget.ck-horizontal-line {
+  &.ck-widget_selected:not(.ck-widget_type-around_show-fake-caret_before,
+    .ck-widget_type-around_show-fake-caret_after) {
+    outline-color: transparent !important;
+    border-radius: var(--ck-border-radius) !important;
+    box-shadow: var(--ck-focus-outer-shadow), 0 0;
+
+    & hr {
+      background-color: var(--ck-color-base-focus);
+    }
+  }
 }

--- a/src/stories/theme/_horizontal-line.css
+++ b/src/stories/theme/_horizontal-line.css
@@ -1,3 +1,5 @@
 .ck-content hr {
-  margin: var(--ck-spacing-unit) 0;
+  margin: var(--ck-spacing-extra-large) 0;
+  background-color: #d8dcde; /* GREY-300 */
+  height: 1px;
 }

--- a/src/stories/theme/_link.css
+++ b/src/stories/theme/_link.css
@@ -1,3 +1,3 @@
 .ck .ck-link_selected {
-  border-radius: 2px;
+  background: none;
 }

--- a/src/stories/theme/_list.css
+++ b/src/stories/theme/_list.css
@@ -1,3 +1,41 @@
+/**
+ * [1] - Due to PostCSS limitations in CKEditor we must include our icon
+ *       directly.
+ */
+.ck.ck-list__item {
+  & .ck-button {
+    position: relative;
+    padding: 10px 32px;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transition: opacity .1s ease-in-out;
+      opacity: 0;
+      background: no-repeat 50% / 16px url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' focusable='false' viewBox='0 0 16 16' color='%231f73b7'%3E %3Cpath fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' d='M1 9l4 4L15 3'/%3E %3C/svg%3E"); /* [1] */
+      width: 32px;
+      height: 100%;
+      content: '';
+    }
+
+    &:focus {
+      outline: none;
+      border-color: transparent;
+      box-shadow: none;
+      background-color: var(--ck-color-list-button-hover-background);
+    }
+
+    & .ck-button__label {
+      line-height: 20px;
+    }
+
+    &.ck-on::before {
+      opacity: 1;
+    }
+  }
+}
+
 .ck-content ul {
   margin: 16px 0 16px 20px;
   padding: 0;

--- a/src/stories/theme/_typearound.css
+++ b/src/stories/theme/_typearound.css
@@ -1,16 +1,19 @@
 /* stylelint-disable selector-max-compound-selectors,
-   selector-combinator-space-before, indentation */
+   selector-combinator-space-before, indentation,
+   declaration-no-important, no-descending-specificity */
 
 @import '@ckeditor/ckeditor5-theme-lark/theme/mixins/_focus.css';
 
 .ck .ck-widget {
   &.ck-widget_selected {
-    box-shadow: var(--ck-focus-outer-shadow), 0 0;
-
     &.ck-widget_type-around_show-fake-caret_before,
 		&.ck-widget_type-around_show-fake-caret_after {
-			box-shadow: none;
+      outline-color: transparent !important;
 		}
+  }
+
+  &:not(.ck-widget_selected):hover {
+    outline-color: transparent !important;
   }
 
   & > .ck-widget__type-around > .ck-widget__type-around__fake-caret {

--- a/src/stories/theme/_typearound.css
+++ b/src/stories/theme/_typearound.css
@@ -1,0 +1,101 @@
+/* stylelint-disable selector-max-compound-selectors,
+   selector-combinator-space-before, indentation */
+
+@import '@ckeditor/ckeditor5-theme-lark/theme/mixins/_focus.css';
+
+.ck .ck-widget {
+  &.ck-widget_selected {
+    box-shadow: var(--ck-focus-outer-shadow), 0 0;
+
+    &.ck-widget_type-around_show-fake-caret_before,
+		&.ck-widget_type-around_show-fake-caret_after {
+			box-shadow: none;
+		}
+  }
+
+  & > .ck-widget__type-around > .ck-widget__type-around__fake-caret {
+    display: none;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 100%;
+  }
+
+  &.ck-widget_type-around_show-fake-caret_before
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    display: block;
+    top: 0;
+    bottom: 0;
+    left: -2px;
+    width: 1px;
+  }
+
+  &.ck-widget_type-around_show-fake-caret_after
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    display: block;
+    top: 0;
+    right: -2px;
+    bottom: 0;
+    left: unset;
+    width: 1px;
+  }
+
+  &:hover.ck-widget_type-around_show-fake-caret_before
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    top: 0;
+    bottom: 0;
+    left: calc((-1 * var(--ck-widget-outline-thickness)) - 2px);
+  }
+
+  &:hover.ck-widget_type-around_show-fake-caret_after
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    top: 0;
+    right: calc((-1 * var(--ck-widget-outline-thickness)) - 2px);
+    bottom: 0;
+  }
+}
+
+.ck[dir='rtl'] .ck-widget {
+  &.ck-widget_type-around_show-fake-caret_before
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    display: block;
+    top: 0;
+    right: -2px;
+    bottom: 0;
+    width: 1px;
+  }
+
+  &.ck-widget_type-around_show-fake-caret_after
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    display: block;
+    top: 0;
+    right: unset;
+    bottom: 0;
+    left: -2px;
+    width: 1px;
+  }
+
+  &:hover.ck-widget_type-around_show-fake-caret_before
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    top: 0;
+    right: calc((-1 * var(--ck-widget-outline-thickness)) - 2px);
+    bottom: 0;
+  }
+
+  &:hover.ck-widget_type-around_show-fake-caret_after
+    > .ck-widget__type-around
+    > .ck-widget__type-around__fake-caret {
+    top: 0;
+    bottom: 0;
+    left: calc((-1 * var(--ck-widget-outline-thickness)) - 2px);
+  }
+}

--- a/src/stories/theme/_variables.css
+++ b/src/stories/theme/_variables.css
@@ -2,8 +2,20 @@
 
 :root {
   /* FONTS */
-  /* stylelint-disable-next-line value-keyword-case */
-  --ck-font-face: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, sans-serif;
+  /* stylelint-disable value-keyword-case */
+  --ck-font-face:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Oxygen-Sans,
+    Ubuntu,
+    Cantarell,
+    Helvetica Neue,
+    Arial,
+    sans-serif;
+  /* stylelint-enable value-keyword-case */
   --ck-font-size-base: 14px;
   --ck-line-height-base: 1.84615;
   --ck-font-size-tiny: 10px;
@@ -20,6 +32,8 @@
   --ck-color-base-focus: #1f73b7; /* BLUE-600 */
   --ck-color-base-text: #2f3941; /* GREY-800  */
   --ck-color-base-error: #cc3340; /* RED-600 */
+  --ck-color-focus-border: var(--ck-color-base-focus);
+  --ck-color-focus-outer-shadow: rgba(31, 115, 183, .35); /* BLUE-600 w/ alpha */
 
   /* SPACING */
   --ck-spacing-unit: 4px;
@@ -33,6 +47,7 @@
 
   /* BORDERS */
   --ck-border-radius: var(--ck-spacing-unit);
+  --ck-border-radius-small: var(--ck-spacing-small);
 
   /* ICONS */
   --ck-icon-size: var(--ck-spacing-extra-large);
@@ -47,6 +62,7 @@
   --ck-drop-shadow: var(--ck-color-shadow-drop) 0 20px 30px 0;
 
   /* WIDGET */
+  --ck-widget-outline-thickness: 1px;
   --ck-color-widget-hover-border: #fed6a8; /* YELLOW-300 */
 
   /* BUTTONS */
@@ -54,7 +70,7 @@
   --ck-color-button-default-hover-background: rgba(31, 115, 183, .08);
   --ck-color-button-default-active-background: rgba(31, 115, 183, .2);
   --ck-color-button-default-active-shadow: transparent; /* TODO NEEDS WORK */
-  --ck-color-button-default-disabled-background: #d8dcde; /* GREY-300 */
+  --ck-color-button-default-disabled-background: transparent;
   --ck-color-button-on-background: var(--ck-color-button-default-active-background);
   --ck-color-button-on-hover-background: var(--ck-color-button-default-active-background);
   --ck-color-button-on-active-background: var(--ck-color-button-default-active-background);
@@ -63,4 +79,9 @@
 
   /* DROPDOWNS */
   --ck-dropdown-arrow-size: var(--ck-spacing-extra-large);
+
+  /* LISTS */
+  --ck-color-list-button-on-background: inherit;
+  --ck-color-list-button-on-background-focus: var(--ck-color-list-button-hover-background);
+  --ck-color-list-button-on-text: var(--ck-color-base-text);
 }

--- a/src/stories/theme/styles.css
+++ b/src/stories/theme/styles.css
@@ -8,5 +8,7 @@
 @import './_typography.css';
 @import './_list.css';
 @import './_code.css';
+@import './_code-block.css';
 @import './_link.css';
 @import './_tooltip.css';
+@import './_typearound.css';

--- a/src/stories/theme/styles.css
+++ b/src/stories/theme/styles.css
@@ -1,5 +1,6 @@
 @import './_variables.css';
 @import './_button.css';
+@import './_dropdown.css';
 @import './_editor.css';
 @import './_balloon-panel.css';
 @import './_toolbar.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,6 +1830,28 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@storybook/addon-a11y@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-6.1.15.tgz#771438627cab24ab948bf7117af09da39a382241"
+  integrity sha512-iD6aXdX4arhRPZVSP/6Tpl1Si7WKb0pISORpi1lt1BNwoRxIauxRCVypEZPGM4R5SDEthU0SiBAHluMmORtd+w==
+  dependencies:
+    "@storybook/addons" "6.1.15"
+    "@storybook/api" "6.1.15"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-api" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/components" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/theming" "6.1.15"
+    axe-core "^4.0.1"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    react-sizeme "^2.5.2"
+    regenerator-runtime "^0.13.7"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-actions@6.1.10":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.1.10.tgz#3742c316e914e2aef661a132e4d7e6c334e89997"
@@ -2010,6 +2032,21 @@
     global "^4.3.2"
     regenerator-runtime "^0.13.7"
 
+"@storybook/addons@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.1.15.tgz#09eb8d962f58bd20b4ac2f83b515831c83226352"
+  integrity sha512-ENyHapLFOG93VaoQXPX8O3IWjLRyVBox9C9P20LMruKX/SfXAXx20qsoAWKKPGssopyOin17aoQX9pj+lFmCZQ==
+  dependencies:
+    "@storybook/api" "6.1.15"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/router" "6.1.15"
+    "@storybook/theming" "6.1.15"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/api@6.1.10":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.10.tgz#7261c43ace576201945bbbc8289b7e0adc174a57"
@@ -2035,6 +2072,31 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.15.tgz#285ba42f7a8efcd3bd0e586a5e978487d826fbb4"
+  integrity sha512-C4D08e2ZbSe62nNKtmh9YBraoWb2j6Chw8VCkuj91kuKHh3YDNc1gjj5Fi+KYZwIcy0EllzW3RFQs+YR1/Vg1g==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "6.1.15"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.1.15"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    regenerator-runtime "^0.13.7"
+    store2 "^2.7.1"
+    telejson "^5.0.2"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@6.1.10":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.10.tgz#570f70c6999ae8cb8957b9990e1a402ff11f74da"
@@ -2048,10 +2110,32 @@
     qs "^6.6.0"
     telejson "^5.0.2"
 
+"@storybook/channel-postmessage@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.15.tgz#80ea2346d18496f9710dd7f87fd2a9eca46ef36f"
+  integrity sha512-Es4B5zpLrW28KSbY8FhGVEDgUnKspJ7wPuJyKExUpZ5L9w52RkTD6lRnVPzLUfoQ4luPsExy5fiuo878/Wc9ag==
+  dependencies:
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    qs "^6.6.0"
+    telejson "^5.0.2"
+
 "@storybook/channels@6.1.10":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.10.tgz#31da5d78052532171846e3e0465832111b65f315"
   integrity sha512-6WyK0OmIy0Gr58JvsmfupquTNsISkGSQX5zgUN2vMMB/rLl7HbddU7/yE/tv/F9fVJag3pXSo3pqlgtdfxXoyw==
+  dependencies:
+    core-js "^3.0.1"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/channels@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.15.tgz#22bb06a671a5ae09d2537bcf63aaf90d7f6b9f6b"
+  integrity sha512-HIKHDeL/0BDk9a7xc2PLiFFoHjUMKUd2djhUGdeKgdKqoWejp4JJ60fI68+2QuSRbkB8k+rAwmuWJzV7EfB5fg==
   dependencies:
     core-js "^3.0.1"
     ts-dedent "^2.0.0"
@@ -2081,10 +2165,42 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/client-api@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.1.15.tgz#8f8ead111459b94621571bdb2276f8a0aace17b1"
+  integrity sha512-iwuDlgNdB6Y4OidlhWPob3tEIax9taymdKEe9by4rLJ3nfXu7viHcvCAjN24oI4NFW3NZsmtqJotgftRYk0r1Q==
+  dependencies:
+    "@storybook/addons" "6.1.15"
+    "@storybook/channel-postmessage" "6.1.15"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/csf" "0.0.1"
+    "@types/qs" "^6.9.0"
+    "@types/webpack-env" "^1.15.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    regenerator-runtime "^0.13.7"
+    stable "^0.1.8"
+    store2 "^2.7.1"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/client-logger@6.1.10":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.10.tgz#491d960387ab336408f596c22f171c19247a1236"
   integrity sha512-06EnESLaNCeHSzsZEEMiy9QtyucTy2BvQ2Z0yPnZLuXTXZNgI6aOtftpehwKSYXdudaIvLkb6xfNvix0BBgHhw==
+  dependencies:
+    core-js "^3.0.1"
+    global "^4.3.2"
+
+"@storybook/client-logger@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.15.tgz#b558d6ecbee82c038d684717d8c598eaa4a9324d"
+  integrity sha512-lUpatG8SxzrUapWMsIPWiR+5qRVT5ebn8tGHQeBeRHXbdmEqyq5DOlrotLUemkA5nNTCs1pMFNvKSpCHznG+fg==
   dependencies:
     core-js "^3.0.1"
     global "^4.3.2"
@@ -2115,10 +2231,43 @@
     react-textarea-autosize "^8.1.1"
     ts-dedent "^2.0.0"
 
+"@storybook/components@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.15.tgz#b4a2af23ee6b9cba4c255191eae3d3463e29bfb7"
+  integrity sha512-lPbA/zyBfctdlpDhRTcRFLWlZPJ3PB4+wI0FUvYs69iG3/bNbQPYu8vRmNhCZOsaGt+b+dik4Tfcth8Bu+eQug==
+  dependencies:
+    "@popperjs/core" "^2.5.4"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.1.15"
+    "@types/overlayscrollbars" "^1.9.0"
+    "@types/react-color" "^3.0.1"
+    "@types/react-syntax-highlighter" "11.0.4"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.11.4"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.10.2"
+    polished "^3.4.4"
+    react-color "^2.17.0"
+    react-popper-tooltip "^3.1.1"
+    react-syntax-highlighter "^13.5.0"
+    react-textarea-autosize "^8.1.1"
+    ts-dedent "^2.0.0"
+
 "@storybook/core-events@6.1.10":
   version "6.1.10"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.10.tgz#e7eff165753c50c2f92adb8cd1576d3799d94e4c"
   integrity sha512-Xv56iXXSf53xiBDW0XEKypfw+1HZw7BN38AISQdbEX5+0y+VLHdWe6vdXIeoXz6ja0lP0Dnrjn4g8usenJzgmA==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.15.tgz#f66e30cbed8afdb8df2254d2aa47fe139e641c60"
+  integrity sha512-2sz02hdGZshanoq83jaB+goAcapVEWrxe+RJZn/gu2OymlEioWNjPPtOVGgi5DNIiJFnYvc66adayNwX39+tDA==
   dependencies:
     core-js "^3.0.1"
 
@@ -2293,6 +2442,18 @@
     memoizerific "^1.11.3"
     qs "^6.6.0"
 
+"@storybook/router@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.15.tgz#e0cd7440a2ddc9b265e506b1cb590d3eeab56476"
+  integrity sha512-HlxDkGpiTSxXCJuqRoZ9Viq6Y/h/7efI8LPhhopr50qWRBTh/PEQzDqWBXG3sj8ISmi9GyUaTSAuqRwdA3lJQQ==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+
 "@storybook/semver@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/semver/-/semver-7.3.2.tgz#f3b9c44a1c9a0b933c04e66d0048fcf2fa10dac0"
@@ -2327,6 +2488,24 @@
     "@emotion/is-prop-valid" "^0.8.6"
     "@emotion/styled" "^10.0.23"
     "@storybook/client-logger" "6.1.10"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.4.4"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
+"@storybook/theming@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.1.15.tgz#01083ab89904dd959429b0b3fd1c76bd0ecc59ef"
+  integrity sha512-88IdYaPzp4NMKf/GKBrPggxD6/d/lkdQ4SNowXxN9g9eONd9M7HtTbjuJGRCbGMJ52xGcbpj2exEnAqKQ2iodA==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.23"
+    "@storybook/client-logger" "6.1.15"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -2563,6 +2742,13 @@
   integrity sha512-RHYataCUPQnt+GHoASyRLq6wmZ0n8jWlBW8Lxcwd30NN6vQfbmTeoSDfkgxO0S1lEzArp8OFDsq5KIs7FygjtA==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/reach__router@^1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.7.tgz#de8ab374259ae7f7499fc1373b9697a5f3cd6428"
+  integrity sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==
+  dependencies:
     "@types/react" "*"
 
 "@types/react-color@^3.0.1":
@@ -3388,7 +3574,7 @@ autoprefixer@^9.7.2, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-axe-core@^4.0.2:
+axe-core@^4.0.1, axe-core@^4.0.2:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
@@ -11372,7 +11558,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-popper-tooltip@^3.1.0:
+react-popper-tooltip@^3.1.0, react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz#329569eb7b287008f04fcbddb6370452ad3f9eac"
   integrity sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==
@@ -11394,7 +11580,7 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-sizeme@^2.6.7:
+react-sizeme@^2.5.2, react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
   integrity sha512-tL4sCgfmvapYRZ1FO2VmBmjPVzzqgHA7kI8lSJ6JS6L78jXFNRdOZFpXyK6P1NBZvKPPCZxReNgzZNUajAerZw==


### PR DESCRIPTION
## Description

This PR adds additional CKEditor theming. Its scope is limited to basic styling and doesn't attempt to override any layout, spacing, or advanced functionality at this time.

## Detail

Some core areas to focus on are:

- Heading dropdown menu now includes Garden selected/hover/focus styling (not updates to menu positioning yet)
- Disabled heading dropdown now aligns with IconButton styling
- The typearound widget now includes vertical before/after cursors instead of the large the default horizontal implementations.
  - This includes new RTL logic for before/after
- The horizontal rules styling is updated including the margin
- The widget focus styling now mimics the default Garden focus ring. I'm unable to modify the border-radius as this time since inline widgets since that is determined by the individual widget. I will look into this more.
- Override code selected background color shift
- Move inline code to be aligned with bold, italic, underline
- Customize `alt+F10` focus states for icon buttons and list focus state.
