### PR TITLE
feat: unify focus styles with new standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@storybook/manager-webpack5": "6.5.16",
     "@storybook/react": "6.5.16",
     "@zendeskgarden/eslint-config": "32.0.0",
-    "@zendeskgarden/react-theming": "8.63.2",
+    "@zendeskgarden/react-theming": "8.67.0",
     "@zendeskgarden/scripts": "1.4.0",
     "@zendeskgarden/stylelint-config": "19.0.0",
     "@zendeskgarden/svg-icons": "6.33.0",

--- a/src/theme/_button.css
+++ b/src/theme/_button.css
@@ -1,10 +1,6 @@
 /* stylelint-disable custom-property-pattern, selector-not-notation */
 
 .ck.ck-button {
-  &:focus {
-    box-shadow: var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
-  }
-
   &:focus,
   &:active {
     border-color: transparent;
@@ -14,7 +10,7 @@
     cursor: pointer;
   }
 
-  &:not(.ck-button-save,.ck-button-cancel) .ck-button__icon {
+  &:not(.ck-button-save, .ck-button-cancel) .ck-button__icon {
     color: $ZD-PALETTE-GREY-600;
   }
 
@@ -24,7 +20,7 @@
     }
   }
 
-  &:hover:not(.ck-disabled,.ck-on,.ck-button-save,.ck-button-cancel) {
+  &:hover:not(.ck-disabled, .ck-on, .ck-button-save, .ck-button-cancel) {
     & .ck-button__icon {
       color: $ZD-PALETTE-GREY-700;
     }

--- a/src/theme/_horizontal-line.css
+++ b/src/theme/_horizontal-line.css
@@ -18,7 +18,7 @@
     .ck-widget_type-around_show-fake-caret_after) {
     outline-color: transparent !important;
     border-radius: var(--ck-border-radius-small) !important;
-    box-shadow: var(--ck-color-focus-outer-shadow) 0 0 0 var(--ck-spacing-small);
+    box-shadow: var(--ck-focus-outer-shadow);
 
     & hr {
       background-color: var(--ck-color-base-focus);

--- a/src/theme/_variables.css
+++ b/src/theme/_variables.css
@@ -20,7 +20,7 @@
   --ck-color-base-text: $ZD-PALETTE-GREY-800;
   --ck-color-base-error: $ZD-PALETTE-RED-600;
   --ck-color-focus-border: var(--ck-color-base-focus);
-  --ck-color-focus-outer-shadow: rgba(31, 115, 183, .35); /* BLUE-600 */
+  --ck-color-focus-outer-shadow: var(--ck-color-base-focus);
 
   /* SPACING */
   --ck-spacing-unit: $ZD-SPACE-XXS;
@@ -45,8 +45,13 @@
 
   /* SHADOWS */
   --ck-color-shadow-drop: rgba(23, 73, 77, .15); /* CHROME-600 */
-  --ck-inner-shadow: var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD inset;
+  --ck-inner-shadow:
+    inset var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
+    inset var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
   --ck-drop-shadow: var(--ck-color-shadow-drop) 0 20px 30px 0;
+  --ck-focus-outer-shadow:
+    var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
+    var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
 
   /* WIDGET */
   --ck-widget-outline-thickness: 1px;

--- a/src/theme/_variables.css
+++ b/src/theme/_variables.css
@@ -21,6 +21,7 @@
   --ck-color-base-error: $ZD-PALETTE-RED-600;
   --ck-color-focus-border: var(--ck-color-base-focus);
   --ck-color-focus-outer-shadow: var(--ck-color-base-focus);
+  --ck-color-focus-disabled-shadow: var(--ck-color-base-focus);
 
   /* SPACING */
   --ck-spacing-unit: $ZD-SPACE-XXS;
@@ -45,13 +46,16 @@
 
   /* SHADOWS */
   --ck-color-shadow-drop: rgba(23, 73, 77, .15); /* CHROME-600 */
+  --ck-drop-shadow: var(--ck-color-shadow-drop) 0 20px 30px 0;
   --ck-inner-shadow:
     inset var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
     inset var(--ck-color-focus-border) 0 0 0 $ZD-SHADOWWIDTHS-MD;
-  --ck-drop-shadow: var(--ck-color-shadow-drop) 0 20px 30px 0;
   --ck-focus-outer-shadow:
     var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
-    var(--ck-color-focus-border) 0 0 0 $ZD-SHADOWWIDTHS-SM;
+    var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-SM;
+  --ck-focus-disabled-outer-shadow:
+    var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
+    var(--ck-color-focus-disabled-shadow) 0 0 0 $ZD-SHADOWWIDTHS-SM;
 
   /* WIDGET */
   --ck-widget-outline-thickness: 1px;

--- a/src/theme/_variables.css
+++ b/src/theme/_variables.css
@@ -47,11 +47,11 @@
   --ck-color-shadow-drop: rgba(23, 73, 77, .15); /* CHROME-600 */
   --ck-inner-shadow:
     inset var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
-    inset var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
+    inset var(--ck-color-focus-border) 0 0 0 $ZD-SHADOWWIDTHS-MD;
   --ck-drop-shadow: var(--ck-color-shadow-drop) 0 20px 30px 0;
   --ck-focus-outer-shadow:
     var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
-    var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
+    var(--ck-color-focus-border) 0 0 0 $ZD-SHADOWWIDTHS-SM;
 
   /* WIDGET */
   --ck-widget-outline-thickness: 1px;
@@ -62,6 +62,7 @@
   --ck-color-button-default-active-background: rgba(31, 115, 183, .2); /* BLUE-600 */
   --ck-color-button-default-active-shadow: transparent;
   --ck-color-button-default-disabled-background: transparent;
+  --ck-color-button-on-color: $ZD-PALETTE-BLUE-800;
   --ck-color-button-on-background: var(--ck-color-button-default-active-background);
   --ck-color-button-on-hover-background: var(--ck-color-button-default-active-background);
   --ck-color-button-on-active-background: var(--ck-color-button-default-active-background);

--- a/src/theme/_variables.css
+++ b/src/theme/_variables.css
@@ -52,10 +52,10 @@
     inset var(--ck-color-focus-border) 0 0 0 $ZD-SHADOWWIDTHS-MD;
   --ck-focus-outer-shadow:
     var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
-    var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-SM;
+    var(--ck-color-focus-outer-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
   --ck-focus-disabled-outer-shadow:
     var(--ck-color-base-background) 0 0 0 $ZD-SHADOWWIDTHS-XS,
-    var(--ck-color-focus-disabled-shadow) 0 0 0 $ZD-SHADOWWIDTHS-SM;
+    var(--ck-color-focus-disabled-shadow) 0 0 0 $ZD-SHADOWWIDTHS-MD;
 
   /* WIDGET */
   --ck-widget-outline-thickness: 1px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,13 +4074,14 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/eslint-config/-/eslint-config-32.0.0.tgz#a4e49f091e44a26b13aec8ed0d63262eb47bbd1b"
   integrity sha512-U38bQxo0b7iUob3rQ1CdrrJ45ZkNYLfrBXoSbSqJglsqZE+oRjBcbYHEH8tVdbhk/BlMPQF1O1i2SSta5Ate9g==
 
-"@zendeskgarden/react-theming@8.63.2":
-  version "8.63.2"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.63.2.tgz#9f9d26b2a3225adeeed33c62a8e190666b1556c5"
-  integrity sha512-V6CuMZjFnNEa/swamb06M6XiuCbETFfMOF8bwzGzH2SzuVBLgRBmutXyKVE5gANuAdUJ9XHkh4DAYZa8I7htTg==
+"@zendeskgarden/react-theming@8.67.0":
+  version "8.67.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.67.0.tgz#9d9201b92f14e003dcc3c38bde76b8062c8d4600"
+  integrity sha512-Vvxek+dqiR1XwDTnqFr22gkzLC+DT1RpfiIJNMp33oXhOqp1GdjaCIaEi+hF4CRHw4fsq0c+2UpqcDFBYoTOCw==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^1.0.0"
     "@zendeskgarden/container-utilities" "^1.0.0"
+    lodash.memoize "^4.1.2"
     polished "^4.0.0"
     prop-types "^15.5.7"
 


### PR DESCRIPTION
## Description

Unifies focus ring across CKEditor with the new focus ring state.

## Detail

[The  global variable `--ck-focus-outer-shadow`](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_focus.css#L15) has been introduced to the `:root` variables to provide elements with a unified focus ring across the editor. The `--ck-inner-shadow` has been updated to the new focus ring state with inset styling.

`@zendeskgarden/react-theming` was updated to bring the latest updates with the `xs` shadow width (`$ZD-SHADOWWIDTHS-XS`).

![Screenshot 2023-05-19 at 3 57 00 PM](https://github.com/zendeskgarden/ckeditor/assets/12474067/633920a8-e7b6-4410-8955-e81fe916b6cf)

![Screenshot 2023-05-19 at 3 57 38 PM](https://github.com/zendeskgarden/ckeditor/assets/12474067/708d3959-653e-4090-be83-22f61fdb4d16)

![Screenshot 2023-05-19 at 3 59 19 PM](https://github.com/zendeskgarden/ckeditor/assets/12474067/6e313e10-8308-4b84-9f95-244605837e17)
