### PR TITLE
fix: missing `husky` command on package install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,11 @@
     "build:storybook": "build-storybook",
     "format": "prettier-package-json --write && yarn format:all --write",
     "format:all": "prettier --loglevel warn '**/*.{js,ts,json,md}' '.storybook/**/*.{js,ts,json,md}' '!CHANGELOG.md' '!dist/**'",
-    "postinstall": "husky install",
     "lint": "yarn lint:js && yarn lint:css && yarn lint:md",
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:js": "eslint src/ .storybook/ --ext js,ts --max-warnings 0",
     "lint:md": "markdownlint README.md src/**/*.md",
-    "prepare": "yarn build",
+    "prepare": "yarn build && husky install",
     "start": "start-storybook -p 6006",
     "tag": "[ `git rev-parse --abbrev-ref HEAD` = 'main' ] && standard-version --no-verify",
     "test": "prettier-package-json --list-different && yarn format:all --check && yarn lint"


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The lastest package release (both `0.1.1` and `0.2.0`) were published without considering the affect of #24. This fix moves the `husky install` command from `postinstall` to `prepare` (which does not run on install) so that consumers are not affected by the missing `husky` dev dependency.

## Detail

closes #91 
